### PR TITLE
Manual Bounding Box Selection

### DIFF
--- a/src/main/Main.cpp
+++ b/src/main/Main.cpp
@@ -50,10 +50,24 @@ void Main::doWork() {
 		if(initialBB == NULL) {
 			initialBB = new int[4];
 		}
+
 		initialBB[0] = box.x;
 		initialBB[1] = box.y;
-		initialBB[2] = box.width;
-		initialBB[3] = box.height;
+		
+		if (box.width < 0) {
+			initialBB[0] += box.width;
+			initialBB[2] = abs(box.width);
+		}
+		else {
+			initialBB[2] = box.width;
+		}
+		if (box.height < 0) {
+			initialBB[1] += box.height;
+			initialBB[3] = abs(box.height);
+		}
+		else {
+			initialBB[3] = box.height;
+		}
 	}
 
 


### PR DESCRIPTION
Hello Georg,

This is a fix for a very minor bug that really had me confused for awhile. When manually selecting a bounding box, unless you draw it from top left to bottom right, the program was crashing with an error message similar to below:

<pre>
ld@void:~/OpenTLD/build/bin$ ./tld
Starting at 21 473 -15 -15
OpenCV Error: Assertion failed (0 &lt;= roi.x && 0 &lt;= roi.width && roi.x + roi.width &lt;= m.cols && 0 &lt;= roi.y && 0 &lt;= roi.height && roi.y + roi.height &lt;= m.rows) in Mat, file /home/ld/OpenCV-2.3.1/modules/core/src/matrix.cpp, line 303

terminate called after throwing an instance of 'cv::Exception'
  what():  /home/ld/OpenCV-2.3.1/modules/core/src/matrix.cpp:303: error: (-215) 0 &lt;= roi.x && 0 &lt;= roi.width && roi.x + roi.width &lt;= m.cols && 0 &lt;= roi.y && 0 &lt;= roi.height && roi.y + roi.height &lt;= m.rows in function Mat

Aborted
</pre>


The fix for it is really simple, just testing for negative values in the bounding box and adjusting them as necessary.

OpenTLD is extremely impressive! Thanks for porting it to C++!
