### PR TITLE
Tidier debian-package rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ Generate Package
 * Debian package
 	* Navigate with the terminal into the root dictionary of OpenTLD (OpenTLD/)
 	* Type `debuild -us -uc`
-	* (For now it's not possible to `make clean` therefore there are lots of remaining junk files in the source tree after the package-build)
+	* Delete the temporary files in the source tree with `debuild clean`
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,20 +1,9 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
 %:
 	dh $@ 
-
-override_dh_auto_configure:
-	cmake -DCMAKE_INSTALL_PREFIX=$(curdir)/usr
-
-override_dh_binary:
-	make install
 


### PR DESCRIPTION
The CMake generated files have now a separated folder (in my case _obj-x86_64-linux-gnu_).
It's also possible to clean after building (`debuild clean`)
