### PR TITLE
Fix compilation on Mac OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,12 @@ project(OpenTLD)
 
 cmake_minimum_required(VERSION 2.6)
 
+set(CMAKE_CXX_STANDARD 11)
+
 find_package(OpenCV REQUIRED)
 
 if(BUILD_QOPENTLD)
-    find_package(Qt4 REQUIRED)
+	find_package(Qt5Widgets)
 endif(BUILD_QOPENTLD)
 
 #-------------------------------------------------------------------------------

--- a/src/libopentld/tld/MedianFlowTracker.cpp
+++ b/src/libopentld/tld/MedianFlowTracker.cpp
@@ -60,7 +60,7 @@ void MedianFlowTracker::track(const Mat &prevMat, const Mat &currMat, Rect *prev
             return;
         }
 
-        float bb_tracker[] = {prevBB->x, prevBB->y, prevBB->width + prevBB->x - 1, prevBB->height + prevBB->y - 1};
+        float bb_tracker[] = {(float)prevBB->x, (float)prevBB->y, (float)(prevBB->width + prevBB->x - 1), (float)(prevBB->height + prevBB->y - 1)};
         float scale;
 
         IplImage prevImg = prevMat;


### PR DESCRIPTION
This PR switches fixes a compilation issue caused by clang following the C++11 spec closer than g++.

It also switches CMakeLists to use Qt5 instead of Qt4.