### PR TITLE
fix ambiguous abs() calls in GCC 6

### DIFF
--- a/src/libopentld/mftracker/BBPredict.cpp
+++ b/src/libopentld/mftracker/BBPredict.cpp
@@ -28,6 +28,7 @@
 #include "BBPredict.h"
 
 #include <cmath>
+#include <cstdlib>
 
 #include "Median.h"
 
@@ -37,7 +38,7 @@
  */
 float getBbWidth(float *bb)
 {
-    return abs(bb[2] - bb[0] + 1);
+    return std::abs(bb[2] - bb[0] + 1);
 }
 /**
  * Returns hight of Boundingbox.
@@ -45,7 +46,7 @@ float getBbWidth(float *bb)
  */
 float getBbHeight(float *bb)
 {
-    return abs(bb[3] - bb[1] + 1);
+    return std::abs(bb[3] - bb[1] + 1);
 }
 /**
  * Calculates the new (moved and resized) Bounding box.


### PR DESCRIPTION
Run into this while compiling on openSUSE Tumbleweed with GCC 6.1.1.
